### PR TITLE
fix(shutdown): graceful shutdown — esperar todos los workers antes de salir [staging]

### DIFF
--- a/server.js
+++ b/server.js
@@ -2779,71 +2779,95 @@ async function collectMetrics() {
     });
 }
 
-/**
- * Close all queue connections gracefully
- * @param {Function} cb - Callback when complete
- */
-const closeQueues = cb => {
-    let proms = [];
-    if (queueEvents.notify) {
-        proms.push(queueEvents.notify.close());
+// Sin timeout artificial — se espera a que todos los workers terminen su job activo.
+// K8s garantiza el cierre final con terminationGracePeriodSeconds en el deployment.
+
+const gracefulShutdown = async signal => {
+    if (isClosing) {
+        return;
     }
+    isClosing = true;
 
-    if (queueEvents.submit) {
-        proms.push(queueEvents.submit.close());
-    }
+    const shutdownStart = Date.now();
+    const podName = process.env.HOSTNAME || os.hostname();
+    const timestamp = new Date().toISOString();
 
-    if (queueEvents.documents) {
-        proms.push(queueEvents.documents.close());
-    }
-
-    if (!proms.length) {
-        return setImmediate(() => cb());
-    }
-
-    let returned;
-
-    let closeTimeout = setTimeout(() => {
-        clearTimeout(closeTimeout);
-        if (returned) {
-            return;
+    // Recopilar todos los workers activos con su tipo antes de empezar
+    const activeWorkersList = [];
+    for (const [type, workerSet] of workers.entries()) {
+        for (const w of workerSet) {
+            activeWorkersList.push({ type, worker: w, threadId: w.threadId });
         }
-        returned = true;
-        cb();
-    }, 2500);
+    }
+    const workerCount = activeWorkersList.length;
+    const workerTypes = [...new Set(activeWorkersList.map(w => w.type))].join(', ');
 
-    Promise.allSettled(proms).then(() => {
-        clearTimeout(closeTimeout);
-        if (returned) {
-            return;
-        }
-        returned = true;
-        cb();
+    logger.info({
+        msg: '================================================================\n GRACEFUL SHUTDOWN INICIADO\n================================================================',
+        signal,
+        pod: podName,
+        timestamp,
+        workers: workerCount,
+        workerTypes
     });
+
+    // Enviar señal de shutdown a cada WorkerThread
+    const workerExitPromises = activeWorkersList.map(({ type, worker, threadId }) => {
+        return new Promise(resolve => {
+            const workerStart = Date.now();
+
+            worker.once('exit', code => {
+                const elapsed = ((Date.now() - workerStart) / 1000).toFixed(1);
+                logger.info({ msg: `[SHUTDOWN] Worker ${type} terminado (code: ${code}) - ${elapsed}s`, type, threadId, code, elapsed });
+                resolve({ type, code });
+            });
+
+            try {
+                worker.postMessage({ cmd: 'gracefulShutdown' });
+                logger.info({ msg: `[SHUTDOWN] Señal enviada a worker: ${type} (threadId: ${threadId})`, type, threadId });
+            } catch (err) {
+                logger.warn({ msg: `[SHUTDOWN] No se pudo enviar señal a worker ${type}`, type, threadId, err: err.message });
+                resolve({ type, code: -1 });
+            }
+        });
+    });
+
+    // Esperar a que TODOS los workers terminen su job activo antes de continuar.
+    await Promise.allSettled(workerExitPromises);
+
+    // Cerrar QueueEvents de BullMQ
+    const queueCloseProms = [];
+    if (queueEvents.notify) queueCloseProms.push(queueEvents.notify.close());
+    if (queueEvents.submit) queueCloseProms.push(queueEvents.submit.close());
+    if (queueEvents.documents) queueCloseProms.push(queueEvents.documents.close());
+    if (queueCloseProms.length) {
+        await Promise.allSettled(queueCloseProms);
+        logger.info({ msg: '[SHUTDOWN] QueueEvents cerrados' });
+    }
+
+    const totalElapsed = ((Date.now() - shutdownStart) / 1000).toFixed(1);
+    const finalWorkerCount = [...workers.values()].reduce((sum, set) => sum + set.size, 0);
+
+    logger.info({
+        msg: '================================================================\n SHUTDOWN COMPLETADO\n================================================================',
+        totalElapsed: `${totalElapsed}s`,
+        workersAlInicio: workerCount,
+        workersAlFinal: finalWorkerCount,
+        exitCode: 0
+    });
+
+    logger.flush(() => process.exit(0));
 };
 
-// Handle graceful shutdown
-process.on('SIGTERM', () => {
-    logger.info({ msg: 'Shutdown signal received', signal: 'SIGTERM', isClosing });
-    if (isClosing) {
-        return;
-    }
-    isClosing = true;
-    closeQueues(() => {
-        logger.flush(() => process.exit());
-    });
-});
+process.on('SIGTERM', () => gracefulShutdown('SIGTERM').catch(err => {
+    logger.error({ msg: 'Error durante graceful shutdown', err });
+    process.exit(1);
+}));
 
-process.on('SIGINT', () => {
-    logger.info({ msg: 'Shutdown signal received', signal: 'SIGINT', isClosing });
-    if (isClosing) {
-        return;
-    }
-    isClosing = true;
-    closeQueues(() => {
-        logger.flush(() => process.exit());
-    });
-});
+process.on('SIGINT', () => gracefulShutdown('SIGINT').catch(err => {
+    logger.error({ msg: 'Error durante graceful shutdown', err });
+    process.exit(1);
+}));
 
 // START APPLICATION
 

--- a/workers/api.js
+++ b/workers/api.js
@@ -499,6 +499,12 @@ parentPort.on('message', message => {
             });
     }
 
+    if (message && message.cmd === 'gracefulShutdown') {
+        logger.info({ msg: '[SHUTDOWN] Worker api: cerrando' });
+        logger.flush(() => process.exit(0));
+        return;
+    }
+
     if (message && message.cmd === 'change') {
         publishChangeEvent(message);
     }

--- a/workers/documents.js
+++ b/workers/documents.js
@@ -148,6 +148,21 @@ parentPort.on('message', message => {
         }
     }
 
+    if (message && message.cmd === 'gracefulShutdown') {
+        logger.info({ msg: '[SHUTDOWN] Worker documents: cerrando documentsWorker (esperando job activo)' });
+        documentsWorker
+            .close()
+            .then(() => {
+                logger.info({ msg: '[SHUTDOWN] Worker documents: documentsWorker cerrado' });
+                process.exit(0);
+            })
+            .catch(err => {
+                logger.error({ msg: '[SHUTDOWN] Worker documents: error cerrando documentsWorker', err });
+                process.exit(1);
+            });
+        return;
+    }
+
     if (message && message.cmd === 'call' && message.mid) {
         return onCommand(message.message)
             .then(response => {

--- a/workers/imap-proxy.js
+++ b/workers/imap-proxy.js
@@ -55,6 +55,12 @@ setInterval(() => {
 parentPort.postMessage({ cmd: 'ready' });
 
 parentPort.on('message', message => {
+    if (message && message.cmd === 'gracefulShutdown') {
+        logger.info({ msg: '[SHUTDOWN] Worker imap-proxy: cerrando' });
+        logger.flush(() => process.exit(0));
+        return;
+    }
+
     if (message && message.cmd === 'call' && message.mid) {
         return onCommand(message.message)
             .then(response => {

--- a/workers/imap.js
+++ b/workers/imap.js
@@ -949,6 +949,21 @@ parentPort.on('message', message => {
         }
     }
 
+    if (message && message.cmd === 'gracefulShutdown') {
+        logger.info({ msg: '[SHUTDOWN] Worker imap: iniciando kill de conexiones IMAP' });
+        connectionHandler
+            .kill()
+            .then(() => {
+                logger.info({ msg: '[SHUTDOWN] Worker imap: conexiones IMAP cerradas' });
+                process.exit(0);
+            })
+            .catch(err => {
+                logger.error({ msg: '[SHUTDOWN] Worker imap: error en kill', err });
+                process.exit(1);
+            });
+        return;
+    }
+
     if (message && message.cmd === 'call' && message.mid) {
         return connectionHandler
             .onCommand(message.message)

--- a/workers/smtp.js
+++ b/workers/smtp.js
@@ -513,6 +513,12 @@ parentPort.on('message', message => {
         }
     }
 
+    if (message && message.cmd === 'gracefulShutdown') {
+        logger.info({ msg: '[SHUTDOWN] Worker smtp: cerrando' });
+        logger.flush(() => process.exit(0));
+        return;
+    }
+
     if (message && message.cmd === 'call' && message.mid) {
         return onCommand(message.message)
             .then(response => {

--- a/workers/submit.js
+++ b/workers/submit.js
@@ -455,6 +455,21 @@ parentPort.on('message', message => {
         }
     }
 
+    if (message && message.cmd === 'gracefulShutdown') {
+        logger.info({ msg: '[SHUTDOWN] Worker submit: cerrando submitWorker (esperando job activo)' });
+        submitWorker
+            .close()
+            .then(() => {
+                logger.info({ msg: '[SHUTDOWN] Worker submit: submitWorker cerrado' });
+                process.exit(0);
+            })
+            .catch(err => {
+                logger.error({ msg: '[SHUTDOWN] Worker submit: error cerrando submitWorker', err });
+                process.exit(1);
+            });
+        return;
+    }
+
     if (message && message.cmd === 'call' && message.mid) {
         return onCommand(message.message)
             .then(response => {

--- a/workers/webhooks.js
+++ b/workers/webhooks.js
@@ -157,6 +157,21 @@ parentPort.on('message', message => {
         }
     }
 
+    if (message && message.cmd === 'gracefulShutdown') {
+        logger.info({ msg: '[SHUTDOWN] Worker webhooks: cerrando notifyWorker (esperando job activo)' });
+        notifyWorker
+            .close()
+            .then(() => {
+                logger.info({ msg: '[SHUTDOWN] Worker webhooks: notifyWorker cerrado' });
+                process.exit(0);
+            })
+            .catch(err => {
+                logger.error({ msg: '[SHUTDOWN] Worker webhooks: error cerrando notifyWorker', err });
+                process.exit(1);
+            });
+        return;
+    }
+
     if (message && message.cmd === 'call' && message.mid) {
         return onCommand(message.message)
             .then(response => {


### PR DESCRIPTION
## Resumen

- Reemplaza `closeQueues()` (2.5s timeout) por `gracefulShutdown()` completo
- Envía `{ cmd: 'gracefulShutdown' }` a los 7 WorkerThreads vía `postMessage`
- Workers BullMQ (`webhooks`, `submit`, `documents`): llaman `worker.close()` → esperan que el job activo termine antes de salir
- Workers no-BullMQ (`imap`, `api`, `smtp`, `imap-proxy`): exit limpio
- Main thread hace `Promise.allSettled` — **sin timeout artificial**, ningún job queda cortado
- Logs estructurados: `GRACEFUL SHUTDOWN INICIADO` / `SHUTDOWN COMPLETADO`

## Test plan

- [ ] Deploy a staging y verificar que el pod inicia correctamente
- [ ] Triggear un rolling update y revisar logs: debe aparecer `GRACEFUL SHUTDOWN INICIADO` y `SHUTDOWN COMPLETADO`
- [ ] Verificar que no hay jobs BullMQ en estado `failed` tras el restart
- [ ] Confirmar `Workers al final: 0` en los logs antes del exit

🤖 Generated with [Claude Code](https://claude.com/claude-code)