### PR TITLE
fix(shutdown): graceful shutdown — esperar todos los workers antes de salir

### DIFF
--- a/server.js
+++ b/server.js
@@ -1977,66 +1977,95 @@ async function collectMetrics() {
     });
 }
 
-const closeQueues = cb => {
-    let proms = [];
-    if (queueEvents.notify) {
-        proms.push(queueEvents.notify.close());
+// Sin timeout artificial — se espera a que todos los workers terminen su job activo.
+// K8s garantiza el cierre final con terminationGracePeriodSeconds en el deployment.
+
+const gracefulShutdown = async signal => {
+    if (isClosing) {
+        return;
     }
+    isClosing = true;
 
-    if (queueEvents.submit) {
-        proms.push(queueEvents.submit.close());
-    }
+    const shutdownStart = Date.now();
+    const podName = process.env.HOSTNAME || os.hostname();
+    const timestamp = new Date().toISOString();
 
-    if (queueEvents.documents) {
-        proms.push(queueEvents.documents.close());
-    }
-
-    if (!proms.length) {
-        return setImmediate(() => cb());
-    }
-
-    let returned;
-
-    let closeTimeout = setTimeout(() => {
-        clearTimeout(closeTimeout);
-        if (returned) {
-            return;
+    // Recopilar todos los workers activos con su tipo antes de empezar
+    const activeWorkersList = [];
+    for (const [type, workerSet] of workers.entries()) {
+        for (const w of workerSet) {
+            activeWorkersList.push({ type, worker: w, threadId: w.threadId });
         }
-        returned = true;
-        cb();
-    }, 2500);
+    }
+    const workerCount = activeWorkersList.length;
+    const workerTypes = [...new Set(activeWorkersList.map(w => w.type))].join(', ');
 
-    Promise.allSettled(proms).then(() => {
-        clearTimeout(closeTimeout);
-        if (returned) {
-            return;
-        }
-        returned = true;
-        cb();
+    logger.info({
+        msg: '================================================================\n GRACEFUL SHUTDOWN INICIADO\n================================================================',
+        signal,
+        pod: podName,
+        timestamp,
+        workers: workerCount,
+        workerTypes
     });
+
+    // Enviar señal de shutdown a cada WorkerThread
+    const workerExitPromises = activeWorkersList.map(({ type, worker, threadId }) => {
+        return new Promise(resolve => {
+            const workerStart = Date.now();
+
+            worker.once('exit', code => {
+                const elapsed = ((Date.now() - workerStart) / 1000).toFixed(1);
+                logger.info({ msg: `[SHUTDOWN] Worker ${type} terminado (code: ${code}) - ${elapsed}s`, type, threadId, code, elapsed });
+                resolve({ type, code });
+            });
+
+            try {
+                worker.postMessage({ cmd: 'gracefulShutdown' });
+                logger.info({ msg: `[SHUTDOWN] Señal enviada a worker: ${type} (threadId: ${threadId})`, type, threadId });
+            } catch (err) {
+                logger.warn({ msg: `[SHUTDOWN] No se pudo enviar señal a worker ${type}`, type, threadId, err: err.message });
+                resolve({ type, code: -1 });
+            }
+        });
+    });
+
+    // Esperar a que TODOS los workers terminen su job activo antes de continuar.
+    await Promise.allSettled(workerExitPromises);
+
+    // Cerrar QueueEvents de BullMQ
+    const queueCloseProms = [];
+    if (queueEvents.notify) queueCloseProms.push(queueEvents.notify.close());
+    if (queueEvents.submit) queueCloseProms.push(queueEvents.submit.close());
+    if (queueEvents.documents) queueCloseProms.push(queueEvents.documents.close());
+    if (queueCloseProms.length) {
+        await Promise.allSettled(queueCloseProms);
+        logger.info({ msg: '[SHUTDOWN] QueueEvents cerrados' });
+    }
+
+    const totalElapsed = ((Date.now() - shutdownStart) / 1000).toFixed(1);
+    const finalWorkerCount = [...workers.values()].reduce((sum, set) => sum + set.size, 0);
+
+    logger.info({
+        msg: '================================================================\n SHUTDOWN COMPLETADO\n================================================================',
+        totalElapsed: `${totalElapsed}s`,
+        workersAlInicio: workerCount,
+        workersAlFinal: finalWorkerCount,
+        exitCode: 0
+    });
+
+    logger.flush(() => process.exit(0));
 };
 
-process.on('SIGTERM', () => {
-    logger.info({ msg: 'Close signal received', signal: 'SIGTERM', isClosing });
-    if (isClosing) {
-        return;
-    }
-    isClosing = true;
-    closeQueues(() => {
-        logger.flush(() => process.exit());
-    });
-});
+process.on('SIGTERM', () => gracefulShutdown('SIGTERM').catch(err => {
+    logger.error({ msg: 'Error durante graceful shutdown', err });
+    process.exit(1);
+}));
 
-process.on('SIGINT', () => {
-    logger.info({ msg: 'Close signal received', signal: 'SIGINT', isClosing });
-    if (isClosing) {
-        return;
-    }
-    isClosing = true;
-    closeQueues(() => {
-        logger.flush(() => process.exit());
-    });
-});
+process.on('SIGINT', () => gracefulShutdown('SIGINT').catch(err => {
+    logger.error({ msg: 'Error durante graceful shutdown', err });
+    process.exit(1);
+}));
 
 // START APPLICATION
 

--- a/server.js
+++ b/server.js
@@ -2005,14 +2005,15 @@ const gracefulShutdown = async signal => {
     const workerCount = activeWorkersList.length;
     const workerTypes = [...new Set(activeWorkersList.map(w => w.type))].join(', ');
 
-    logger.info({
-        msg: '================================================================\n GRACEFUL SHUTDOWN INICIADO\n================================================================',
-        signal,
-        pod: podName,
-        timestamp,
-        workers: workerCount,
-        workerTypes
-    });
+    const SEP = '================================================================';
+    console.log(`\n${SEP}`);
+    console.log(` GRACEFUL SHUTDOWN INICIADO`);
+    console.log(SEP);
+    console.log(` Signal:              ${signal}`);
+    console.log(` Pod:                 ${podName}`);
+    console.log(` Timestamp:           ${timestamp}`);
+    console.log(` Workers al inicio:   ${workerCount} (${workerTypes})`);
+    console.log(`${SEP}\n`);
 
     // Enviar señal de shutdown a cada WorkerThread
     const workerExitPromises = activeWorkersList.map(({ type, worker, threadId }) => {
@@ -2021,15 +2022,15 @@ const gracefulShutdown = async signal => {
 
             worker.once('exit', code => {
                 const elapsed = ((Date.now() - workerStart) / 1000).toFixed(1);
-                logger.info({ msg: `[SHUTDOWN] Worker ${type} terminado (code: ${code}) - ${elapsed}s`, type, threadId, code, elapsed });
+                console.log(`[SHUTDOWN] Worker ${type} (threadId: ${threadId}) terminado (code: ${code}) - ${elapsed}s`);
                 resolve({ type, code });
             });
 
             try {
                 worker.postMessage({ cmd: 'gracefulShutdown' });
-                logger.info({ msg: `[SHUTDOWN] Señal enviada a worker: ${type} (threadId: ${threadId})`, type, threadId });
+                console.log(`[SHUTDOWN] Señal enviada a worker: ${type} (threadId: ${threadId})`);
             } catch (err) {
-                logger.warn({ msg: `[SHUTDOWN] No se pudo enviar señal a worker ${type}`, type, threadId, err: err.message });
+                console.log(`[SHUTDOWN] No se pudo enviar señal a worker ${type}: ${err.message}`);
                 resolve({ type, code: -1 });
             }
         });
@@ -2045,19 +2046,20 @@ const gracefulShutdown = async signal => {
     if (queueEvents.documents) queueCloseProms.push(queueEvents.documents.close());
     if (queueCloseProms.length) {
         await Promise.allSettled(queueCloseProms);
-        logger.info({ msg: '[SHUTDOWN] QueueEvents cerrados' });
+        console.log(`[SHUTDOWN] QueueEvents BullMQ cerrados`);
     }
 
     const totalElapsed = ((Date.now() - shutdownStart) / 1000).toFixed(1);
     const finalWorkerCount = [...workers.values()].reduce((sum, set) => sum + set.size, 0);
 
-    logger.info({
-        msg: '================================================================\n SHUTDOWN COMPLETADO\n================================================================',
-        totalElapsed: `${totalElapsed}s`,
-        workersAlInicio: workerCount,
-        workersAlFinal: finalWorkerCount,
-        exitCode: 0
-    });
+    console.log(`\n${SEP}`);
+    console.log(` SHUTDOWN COMPLETADO`);
+    console.log(SEP);
+    console.log(` Tiempo total:        ${totalElapsed}s`);
+    console.log(` Workers al inicio:   ${workerCount}`);
+    console.log(` Workers al final:    ${finalWorkerCount}`);
+    console.log(` Exit code:           0`);
+    console.log(`${SEP}\n`);
 
     logger.flush(() => process.exit(0));
 };

--- a/server.js
+++ b/server.js
@@ -713,13 +713,18 @@ let spawnWorker = async type => {
 
         worker.on('exit', exitCode => {
             if (!isOnline) {
-                let error = new Error(`Failed to start ${type} worker thread on initialization`);
+                if (isClosing) {
+                    // Shutdown llegó antes de que el worker terminara de inicializar — salida limpia
+                    resolve(threadId);
+                } else {
+                    let error = new Error(`Failed to start ${type} worker thread on initialization`);
 
-                error.workerType = type;
-                error.exitCode = exitCode;
-                error.threadId = threadId;
+                    error.workerType = type;
+                    error.exitCode = exitCode;
+                    error.threadId = threadId;
 
-                reject(error);
+                    reject(error);
+                }
             }
 
             exitHandler(exitCode).catch(err => {

--- a/workers/api.js
+++ b/workers/api.js
@@ -485,7 +485,7 @@ parentPort.on('message', message => {
     }
 
     if (message && message.cmd === 'gracefulShutdown') {
-        logger.info({ msg: '[SHUTDOWN] Worker api: cerrando' });
+        console.log('[SHUTDOWN] Worker api: cerrando');
         logger.flush(() => process.exit(0));
         return;
     }

--- a/workers/api.js
+++ b/workers/api.js
@@ -484,6 +484,12 @@ parentPort.on('message', message => {
             });
     }
 
+    if (message && message.cmd === 'gracefulShutdown') {
+        logger.info({ msg: '[SHUTDOWN] Worker api: cerrando' });
+        logger.flush(() => process.exit(0));
+        return;
+    }
+
     if (message && message.cmd === 'change') {
         publishChangeEvent(message);
     }

--- a/workers/documents.js
+++ b/workers/documents.js
@@ -137,15 +137,15 @@ parentPort.on('message', message => {
     }
 
     if (message && message.cmd === 'gracefulShutdown') {
-        logger.info({ msg: '[SHUTDOWN] Worker documents: cerrando documentsWorker (esperando job activo)' });
+        console.log('[SHUTDOWN] Worker documents: cerrando documentsWorker (esperando job activo)');
         documentsWorker
             .close()
             .then(() => {
-                logger.info({ msg: '[SHUTDOWN] Worker documents: documentsWorker cerrado' });
+                console.log('[SHUTDOWN] Worker documents: documentsWorker cerrado');
                 process.exit(0);
             })
             .catch(err => {
-                logger.error({ msg: '[SHUTDOWN] Worker documents: error cerrando documentsWorker', err });
+                console.log(`[SHUTDOWN] Worker documents: error cerrando documentsWorker: ${err.message}`);
                 process.exit(1);
             });
         return;

--- a/workers/documents.js
+++ b/workers/documents.js
@@ -136,6 +136,21 @@ parentPort.on('message', message => {
         }
     }
 
+    if (message && message.cmd === 'gracefulShutdown') {
+        logger.info({ msg: '[SHUTDOWN] Worker documents: cerrando documentsWorker (esperando job activo)' });
+        documentsWorker
+            .close()
+            .then(() => {
+                logger.info({ msg: '[SHUTDOWN] Worker documents: documentsWorker cerrado' });
+                process.exit(0);
+            })
+            .catch(err => {
+                logger.error({ msg: '[SHUTDOWN] Worker documents: error cerrando documentsWorker', err });
+                process.exit(1);
+            });
+        return;
+    }
+
     if (message && message.cmd === 'call' && message.mid) {
         return onCommand(message.message)
             .then(response => {

--- a/workers/imap-proxy.js
+++ b/workers/imap-proxy.js
@@ -43,6 +43,12 @@ async function onCommand(command) {
 }
 
 parentPort.on('message', message => {
+    if (message && message.cmd === 'gracefulShutdown') {
+        logger.info({ msg: '[SHUTDOWN] Worker imap-proxy: cerrando' });
+        logger.flush(() => process.exit(0));
+        return;
+    }
+
     if (message && message.cmd === 'call' && message.mid) {
         return onCommand(message.message)
             .then(response => {

--- a/workers/imap-proxy.js
+++ b/workers/imap-proxy.js
@@ -44,7 +44,7 @@ async function onCommand(command) {
 
 parentPort.on('message', message => {
     if (message && message.cmd === 'gracefulShutdown') {
-        logger.info({ msg: '[SHUTDOWN] Worker imap-proxy: cerrando' });
+        console.log('[SHUTDOWN] Worker imap-proxy: cerrando');
         logger.flush(() => process.exit(0));
         return;
     }

--- a/workers/imap.js
+++ b/workers/imap.js
@@ -864,15 +864,15 @@ parentPort.on('message', message => {
     }
 
     if (message && message.cmd === 'gracefulShutdown') {
-        logger.info({ msg: '[SHUTDOWN] Worker imap: iniciando kill de conexiones IMAP' });
+        console.log('[SHUTDOWN] Worker imap: iniciando kill de conexiones IMAP');
         connectionHandler
             .kill()
             .then(() => {
-                logger.info({ msg: '[SHUTDOWN] Worker imap: conexiones IMAP cerradas' });
+                console.log('[SHUTDOWN] Worker imap: conexiones IMAP cerradas');
                 process.exit(0);
             })
             .catch(err => {
-                logger.error({ msg: '[SHUTDOWN] Worker imap: error en kill', err });
+                console.log(`[SHUTDOWN] Worker imap: error en kill: ${err.message}`);
                 process.exit(1);
             });
         return;

--- a/workers/imap.js
+++ b/workers/imap.js
@@ -863,6 +863,21 @@ parentPort.on('message', message => {
         }
     }
 
+    if (message && message.cmd === 'gracefulShutdown') {
+        logger.info({ msg: '[SHUTDOWN] Worker imap: iniciando kill de conexiones IMAP' });
+        connectionHandler
+            .kill()
+            .then(() => {
+                logger.info({ msg: '[SHUTDOWN] Worker imap: conexiones IMAP cerradas' });
+                process.exit(0);
+            })
+            .catch(err => {
+                logger.error({ msg: '[SHUTDOWN] Worker imap: error en kill', err });
+                process.exit(1);
+            });
+        return;
+    }
+
     if (message && message.cmd === 'call' && message.mid) {
         return connectionHandler
             .onCommand(message.message)

--- a/workers/smtp.js
+++ b/workers/smtp.js
@@ -501,6 +501,12 @@ parentPort.on('message', message => {
         }
     }
 
+    if (message && message.cmd === 'gracefulShutdown') {
+        logger.info({ msg: '[SHUTDOWN] Worker smtp: cerrando' });
+        logger.flush(() => process.exit(0));
+        return;
+    }
+
     if (message && message.cmd === 'call' && message.mid) {
         return onCommand(message.message)
             .then(response => {

--- a/workers/smtp.js
+++ b/workers/smtp.js
@@ -502,7 +502,7 @@ parentPort.on('message', message => {
     }
 
     if (message && message.cmd === 'gracefulShutdown') {
-        logger.info({ msg: '[SHUTDOWN] Worker smtp: cerrando' });
+        console.log('[SHUTDOWN] Worker smtp: cerrando');
         logger.flush(() => process.exit(0));
         return;
     }

--- a/workers/submit.js
+++ b/workers/submit.js
@@ -434,6 +434,21 @@ parentPort.on('message', message => {
         }
     }
 
+    if (message && message.cmd === 'gracefulShutdown') {
+        logger.info({ msg: '[SHUTDOWN] Worker submit: cerrando submitWorker (esperando job activo)' });
+        submitWorker
+            .close()
+            .then(() => {
+                logger.info({ msg: '[SHUTDOWN] Worker submit: submitWorker cerrado' });
+                process.exit(0);
+            })
+            .catch(err => {
+                logger.error({ msg: '[SHUTDOWN] Worker submit: error cerrando submitWorker', err });
+                process.exit(1);
+            });
+        return;
+    }
+
     if (message && message.cmd === 'call' && message.mid) {
         return onCommand(message.message)
             .then(response => {

--- a/workers/submit.js
+++ b/workers/submit.js
@@ -435,15 +435,15 @@ parentPort.on('message', message => {
     }
 
     if (message && message.cmd === 'gracefulShutdown') {
-        logger.info({ msg: '[SHUTDOWN] Worker submit: cerrando submitWorker (esperando job activo)' });
+        console.log('[SHUTDOWN] Worker submit: cerrando submitWorker (esperando job activo)');
         submitWorker
             .close()
             .then(() => {
-                logger.info({ msg: '[SHUTDOWN] Worker submit: submitWorker cerrado' });
+                console.log('[SHUTDOWN] Worker submit: submitWorker cerrado');
                 process.exit(0);
             })
             .catch(err => {
-                logger.error({ msg: '[SHUTDOWN] Worker submit: error cerrando submitWorker', err });
+                console.log(`[SHUTDOWN] Worker submit: error cerrando submitWorker: ${err.message}`);
                 process.exit(1);
             });
         return;

--- a/workers/webhooks.js
+++ b/workers/webhooks.js
@@ -144,6 +144,21 @@ parentPort.on('message', message => {
         }
     }
 
+    if (message && message.cmd === 'gracefulShutdown') {
+        logger.info({ msg: '[SHUTDOWN] Worker webhooks: cerrando notifyWorker (esperando job activo)' });
+        notifyWorker
+            .close()
+            .then(() => {
+                logger.info({ msg: '[SHUTDOWN] Worker webhooks: notifyWorker cerrado' });
+                process.exit(0);
+            })
+            .catch(err => {
+                logger.error({ msg: '[SHUTDOWN] Worker webhooks: error cerrando notifyWorker', err });
+                process.exit(1);
+            });
+        return;
+    }
+
     if (message && message.cmd === 'call' && message.mid) {
         return onCommand(message.message)
             .then(response => {

--- a/workers/webhooks.js
+++ b/workers/webhooks.js
@@ -145,15 +145,15 @@ parentPort.on('message', message => {
     }
 
     if (message && message.cmd === 'gracefulShutdown') {
-        logger.info({ msg: '[SHUTDOWN] Worker webhooks: cerrando notifyWorker (esperando job activo)' });
+        console.log('[SHUTDOWN] Worker webhooks: cerrando notifyWorker (esperando job activo)');
         notifyWorker
             .close()
             .then(() => {
-                logger.info({ msg: '[SHUTDOWN] Worker webhooks: notifyWorker cerrado' });
+                console.log('[SHUTDOWN] Worker webhooks: notifyWorker cerrado');
                 process.exit(0);
             })
             .catch(err => {
-                logger.error({ msg: '[SHUTDOWN] Worker webhooks: error cerrando notifyWorker', err });
+                console.log(`[SHUTDOWN] Worker webhooks: error cerrando notifyWorker: ${err.message}`);
                 process.exit(1);
             });
         return;


### PR DESCRIPTION
## Resumen

- Reemplaza `closeQueues()` (2.5s timeout) por `gracefulShutdown()` completo
- Envía `{ cmd: 'gracefulShutdown' }` a los 7 WorkerThreads vía `postMessage`
- Workers BullMQ (`webhooks`, `submit`, `documents`): llaman `worker.close()` → esperan que el job activo termine antes de salir
- Workers no-BullMQ (`imap`, `api`, `smtp`, `imap-proxy`): exit limpio
- Main thread hace `Promise.allSettled` — **sin timeout artificial**, ningún job queda cortado
- Logs estructurados: `GRACEFUL SHUTDOWN INICIADO` / `SHUTDOWN COMPLETADO`

## Test plan

- [ ] Verificar deploy exitoso a staging antes de mergear a master
- [ ] Triggear rolling update en prod y revisar logs: debe aparecer `GRACEFUL SHUTDOWN INICIADO` y `SHUTDOWN COMPLETADO`
- [ ] Verificar que no hay jobs BullMQ en estado `failed` tras el restart
- [ ] Confirmar `Workers al final: 0` en los logs antes del exit

🤖 Generated with [Claude Code](https://claude.com/claude-code)