### PR TITLE
fix(shutdown): logs de shutdown como texto plano (console.log)

### DIFF
--- a/server.js
+++ b/server.js
@@ -2807,14 +2807,15 @@ const gracefulShutdown = async signal => {
     const workerCount = activeWorkersList.length;
     const workerTypes = [...new Set(activeWorkersList.map(w => w.type))].join(', ');
 
-    logger.info({
-        msg: '================================================================\n GRACEFUL SHUTDOWN INICIADO\n================================================================',
-        signal,
-        pod: podName,
-        timestamp,
-        workers: workerCount,
-        workerTypes
-    });
+    const SEP = '================================================================';
+    console.log(`\n${SEP}`);
+    console.log(` GRACEFUL SHUTDOWN INICIADO`);
+    console.log(SEP);
+    console.log(` Signal:              ${signal}`);
+    console.log(` Pod:                 ${podName}`);
+    console.log(` Timestamp:           ${timestamp}`);
+    console.log(` Workers al inicio:   ${workerCount} (${workerTypes})`);
+    console.log(`${SEP}\n`);
 
     // Enviar señal de shutdown a cada WorkerThread
     const workerExitPromises = activeWorkersList.map(({ type, worker, threadId }) => {
@@ -2823,15 +2824,15 @@ const gracefulShutdown = async signal => {
 
             worker.once('exit', code => {
                 const elapsed = ((Date.now() - workerStart) / 1000).toFixed(1);
-                logger.info({ msg: `[SHUTDOWN] Worker ${type} terminado (code: ${code}) - ${elapsed}s`, type, threadId, code, elapsed });
+                console.log(`[SHUTDOWN] Worker ${type} (threadId: ${threadId}) terminado (code: ${code}) - ${elapsed}s`);
                 resolve({ type, code });
             });
 
             try {
                 worker.postMessage({ cmd: 'gracefulShutdown' });
-                logger.info({ msg: `[SHUTDOWN] Señal enviada a worker: ${type} (threadId: ${threadId})`, type, threadId });
+                console.log(`[SHUTDOWN] Señal enviada a worker: ${type} (threadId: ${threadId})`);
             } catch (err) {
-                logger.warn({ msg: `[SHUTDOWN] No se pudo enviar señal a worker ${type}`, type, threadId, err: err.message });
+                console.log(`[SHUTDOWN] No se pudo enviar señal a worker ${type}: ${err.message}`);
                 resolve({ type, code: -1 });
             }
         });
@@ -2847,19 +2848,20 @@ const gracefulShutdown = async signal => {
     if (queueEvents.documents) queueCloseProms.push(queueEvents.documents.close());
     if (queueCloseProms.length) {
         await Promise.allSettled(queueCloseProms);
-        logger.info({ msg: '[SHUTDOWN] QueueEvents cerrados' });
+        console.log(`[SHUTDOWN] QueueEvents BullMQ cerrados`);
     }
 
     const totalElapsed = ((Date.now() - shutdownStart) / 1000).toFixed(1);
     const finalWorkerCount = [...workers.values()].reduce((sum, set) => sum + set.size, 0);
 
-    logger.info({
-        msg: '================================================================\n SHUTDOWN COMPLETADO\n================================================================',
-        totalElapsed: `${totalElapsed}s`,
-        workersAlInicio: workerCount,
-        workersAlFinal: finalWorkerCount,
-        exitCode: 0
-    });
+    console.log(`\n${SEP}`);
+    console.log(` SHUTDOWN COMPLETADO`);
+    console.log(SEP);
+    console.log(` Tiempo total:        ${totalElapsed}s`);
+    console.log(` Workers al inicio:   ${workerCount}`);
+    console.log(` Workers al final:    ${finalWorkerCount}`);
+    console.log(` Exit code:           0`);
+    console.log(`${SEP}\n`);
 
     logger.flush(() => process.exit(0));
 };

--- a/server.js
+++ b/server.js
@@ -1195,13 +1195,18 @@ let spawnWorker = async type => {
         // Handle worker exit
         worker.on('exit', exitCode => {
             if (!isOnline) {
-                let error = new Error(`Unable to start ${type} worker thread`);
+                if (isClosing) {
+                    // Shutdown llegó antes de que el worker terminara de inicializar — salida limpia
+                    resolve(threadId);
+                } else {
+                    let error = new Error(`Unable to start ${type} worker thread`);
 
-                error.workerType = type;
-                error.exitCode = exitCode;
-                error.threadId = threadId;
+                    error.workerType = type;
+                    error.exitCode = exitCode;
+                    error.threadId = threadId;
 
-                reject(error);
+                    reject(error);
+                }
             }
 
             exitHandler(exitCode).catch(err => {

--- a/server.js
+++ b/server.js
@@ -2779,71 +2779,95 @@ async function collectMetrics() {
     });
 }
 
-/**
- * Close all queue connections gracefully
- * @param {Function} cb - Callback when complete
- */
-const closeQueues = cb => {
-    let proms = [];
-    if (queueEvents.notify) {
-        proms.push(queueEvents.notify.close());
+// Sin timeout artificial — se espera a que todos los workers terminen su job activo.
+// K8s garantiza el cierre final con terminationGracePeriodSeconds en el deployment.
+
+const gracefulShutdown = async signal => {
+    if (isClosing) {
+        return;
     }
+    isClosing = true;
 
-    if (queueEvents.submit) {
-        proms.push(queueEvents.submit.close());
-    }
+    const shutdownStart = Date.now();
+    const podName = process.env.HOSTNAME || os.hostname();
+    const timestamp = new Date().toISOString();
 
-    if (queueEvents.documents) {
-        proms.push(queueEvents.documents.close());
-    }
-
-    if (!proms.length) {
-        return setImmediate(() => cb());
-    }
-
-    let returned;
-
-    let closeTimeout = setTimeout(() => {
-        clearTimeout(closeTimeout);
-        if (returned) {
-            return;
+    // Recopilar todos los workers activos con su tipo antes de empezar
+    const activeWorkersList = [];
+    for (const [type, workerSet] of workers.entries()) {
+        for (const w of workerSet) {
+            activeWorkersList.push({ type, worker: w, threadId: w.threadId });
         }
-        returned = true;
-        cb();
-    }, 2500);
+    }
+    const workerCount = activeWorkersList.length;
+    const workerTypes = [...new Set(activeWorkersList.map(w => w.type))].join(', ');
 
-    Promise.allSettled(proms).then(() => {
-        clearTimeout(closeTimeout);
-        if (returned) {
-            return;
-        }
-        returned = true;
-        cb();
+    logger.info({
+        msg: '================================================================\n GRACEFUL SHUTDOWN INICIADO\n================================================================',
+        signal,
+        pod: podName,
+        timestamp,
+        workers: workerCount,
+        workerTypes
     });
+
+    // Enviar señal de shutdown a cada WorkerThread
+    const workerExitPromises = activeWorkersList.map(({ type, worker, threadId }) => {
+        return new Promise(resolve => {
+            const workerStart = Date.now();
+
+            worker.once('exit', code => {
+                const elapsed = ((Date.now() - workerStart) / 1000).toFixed(1);
+                logger.info({ msg: `[SHUTDOWN] Worker ${type} terminado (code: ${code}) - ${elapsed}s`, type, threadId, code, elapsed });
+                resolve({ type, code });
+            });
+
+            try {
+                worker.postMessage({ cmd: 'gracefulShutdown' });
+                logger.info({ msg: `[SHUTDOWN] Señal enviada a worker: ${type} (threadId: ${threadId})`, type, threadId });
+            } catch (err) {
+                logger.warn({ msg: `[SHUTDOWN] No se pudo enviar señal a worker ${type}`, type, threadId, err: err.message });
+                resolve({ type, code: -1 });
+            }
+        });
+    });
+
+    // Esperar a que TODOS los workers terminen su job activo antes de continuar.
+    await Promise.allSettled(workerExitPromises);
+
+    // Cerrar QueueEvents de BullMQ
+    const queueCloseProms = [];
+    if (queueEvents.notify) queueCloseProms.push(queueEvents.notify.close());
+    if (queueEvents.submit) queueCloseProms.push(queueEvents.submit.close());
+    if (queueEvents.documents) queueCloseProms.push(queueEvents.documents.close());
+    if (queueCloseProms.length) {
+        await Promise.allSettled(queueCloseProms);
+        logger.info({ msg: '[SHUTDOWN] QueueEvents cerrados' });
+    }
+
+    const totalElapsed = ((Date.now() - shutdownStart) / 1000).toFixed(1);
+    const finalWorkerCount = [...workers.values()].reduce((sum, set) => sum + set.size, 0);
+
+    logger.info({
+        msg: '================================================================\n SHUTDOWN COMPLETADO\n================================================================',
+        totalElapsed: `${totalElapsed}s`,
+        workersAlInicio: workerCount,
+        workersAlFinal: finalWorkerCount,
+        exitCode: 0
+    });
+
+    logger.flush(() => process.exit(0));
 };
 
-// Handle graceful shutdown
-process.on('SIGTERM', () => {
-    logger.info({ msg: 'Shutdown signal received', signal: 'SIGTERM', isClosing });
-    if (isClosing) {
-        return;
-    }
-    isClosing = true;
-    closeQueues(() => {
-        logger.flush(() => process.exit());
-    });
-});
+process.on('SIGTERM', () => gracefulShutdown('SIGTERM').catch(err => {
+    logger.error({ msg: 'Error durante graceful shutdown', err });
+    process.exit(1);
+}));
 
-process.on('SIGINT', () => {
-    logger.info({ msg: 'Shutdown signal received', signal: 'SIGINT', isClosing });
-    if (isClosing) {
-        return;
-    }
-    isClosing = true;
-    closeQueues(() => {
-        logger.flush(() => process.exit());
-    });
-});
+process.on('SIGINT', () => gracefulShutdown('SIGINT').catch(err => {
+    logger.error({ msg: 'Error durante graceful shutdown', err });
+    process.exit(1);
+}));
 
 // START APPLICATION
 

--- a/workers/api.js
+++ b/workers/api.js
@@ -499,6 +499,12 @@ parentPort.on('message', message => {
             });
     }
 
+    if (message && message.cmd === 'gracefulShutdown') {
+        logger.info({ msg: '[SHUTDOWN] Worker api: cerrando' });
+        logger.flush(() => process.exit(0));
+        return;
+    }
+
     if (message && message.cmd === 'change') {
         publishChangeEvent(message);
     }

--- a/workers/api.js
+++ b/workers/api.js
@@ -500,7 +500,7 @@ parentPort.on('message', message => {
     }
 
     if (message && message.cmd === 'gracefulShutdown') {
-        logger.info({ msg: '[SHUTDOWN] Worker api: cerrando' });
+        console.log('[SHUTDOWN] Worker api: cerrando');
         logger.flush(() => process.exit(0));
         return;
     }

--- a/workers/documents.js
+++ b/workers/documents.js
@@ -149,15 +149,15 @@ parentPort.on('message', message => {
     }
 
     if (message && message.cmd === 'gracefulShutdown') {
-        logger.info({ msg: '[SHUTDOWN] Worker documents: cerrando documentsWorker (esperando job activo)' });
+        console.log('[SHUTDOWN] Worker documents: cerrando documentsWorker (esperando job activo)');
         documentsWorker
             .close()
             .then(() => {
-                logger.info({ msg: '[SHUTDOWN] Worker documents: documentsWorker cerrado' });
+                console.log('[SHUTDOWN] Worker documents: documentsWorker cerrado');
                 process.exit(0);
             })
             .catch(err => {
-                logger.error({ msg: '[SHUTDOWN] Worker documents: error cerrando documentsWorker', err });
+                console.log(`[SHUTDOWN] Worker documents: error cerrando documentsWorker: ${err.message}`);
                 process.exit(1);
             });
         return;

--- a/workers/documents.js
+++ b/workers/documents.js
@@ -148,6 +148,21 @@ parentPort.on('message', message => {
         }
     }
 
+    if (message && message.cmd === 'gracefulShutdown') {
+        logger.info({ msg: '[SHUTDOWN] Worker documents: cerrando documentsWorker (esperando job activo)' });
+        documentsWorker
+            .close()
+            .then(() => {
+                logger.info({ msg: '[SHUTDOWN] Worker documents: documentsWorker cerrado' });
+                process.exit(0);
+            })
+            .catch(err => {
+                logger.error({ msg: '[SHUTDOWN] Worker documents: error cerrando documentsWorker', err });
+                process.exit(1);
+            });
+        return;
+    }
+
     if (message && message.cmd === 'call' && message.mid) {
         return onCommand(message.message)
             .then(response => {

--- a/workers/imap-proxy.js
+++ b/workers/imap-proxy.js
@@ -56,7 +56,7 @@ parentPort.postMessage({ cmd: 'ready' });
 
 parentPort.on('message', message => {
     if (message && message.cmd === 'gracefulShutdown') {
-        logger.info({ msg: '[SHUTDOWN] Worker imap-proxy: cerrando' });
+        console.log('[SHUTDOWN] Worker imap-proxy: cerrando');
         logger.flush(() => process.exit(0));
         return;
     }

--- a/workers/imap-proxy.js
+++ b/workers/imap-proxy.js
@@ -55,6 +55,12 @@ setInterval(() => {
 parentPort.postMessage({ cmd: 'ready' });
 
 parentPort.on('message', message => {
+    if (message && message.cmd === 'gracefulShutdown') {
+        logger.info({ msg: '[SHUTDOWN] Worker imap-proxy: cerrando' });
+        logger.flush(() => process.exit(0));
+        return;
+    }
+
     if (message && message.cmd === 'call' && message.mid) {
         return onCommand(message.message)
             .then(response => {

--- a/workers/imap.js
+++ b/workers/imap.js
@@ -950,15 +950,15 @@ parentPort.on('message', message => {
     }
 
     if (message && message.cmd === 'gracefulShutdown') {
-        logger.info({ msg: '[SHUTDOWN] Worker imap: iniciando kill de conexiones IMAP' });
+        console.log('[SHUTDOWN] Worker imap: iniciando kill de conexiones IMAP');
         connectionHandler
             .kill()
             .then(() => {
-                logger.info({ msg: '[SHUTDOWN] Worker imap: conexiones IMAP cerradas' });
+                console.log('[SHUTDOWN] Worker imap: conexiones IMAP cerradas');
                 process.exit(0);
             })
             .catch(err => {
-                logger.error({ msg: '[SHUTDOWN] Worker imap: error en kill', err });
+                console.log(`[SHUTDOWN] Worker imap: error en kill: ${err.message}`);
                 process.exit(1);
             });
         return;

--- a/workers/imap.js
+++ b/workers/imap.js
@@ -949,6 +949,21 @@ parentPort.on('message', message => {
         }
     }
 
+    if (message && message.cmd === 'gracefulShutdown') {
+        logger.info({ msg: '[SHUTDOWN] Worker imap: iniciando kill de conexiones IMAP' });
+        connectionHandler
+            .kill()
+            .then(() => {
+                logger.info({ msg: '[SHUTDOWN] Worker imap: conexiones IMAP cerradas' });
+                process.exit(0);
+            })
+            .catch(err => {
+                logger.error({ msg: '[SHUTDOWN] Worker imap: error en kill', err });
+                process.exit(1);
+            });
+        return;
+    }
+
     if (message && message.cmd === 'call' && message.mid) {
         return connectionHandler
             .onCommand(message.message)

--- a/workers/smtp.js
+++ b/workers/smtp.js
@@ -513,6 +513,12 @@ parentPort.on('message', message => {
         }
     }
 
+    if (message && message.cmd === 'gracefulShutdown') {
+        logger.info({ msg: '[SHUTDOWN] Worker smtp: cerrando' });
+        logger.flush(() => process.exit(0));
+        return;
+    }
+
     if (message && message.cmd === 'call' && message.mid) {
         return onCommand(message.message)
             .then(response => {

--- a/workers/smtp.js
+++ b/workers/smtp.js
@@ -514,7 +514,7 @@ parentPort.on('message', message => {
     }
 
     if (message && message.cmd === 'gracefulShutdown') {
-        logger.info({ msg: '[SHUTDOWN] Worker smtp: cerrando' });
+        console.log('[SHUTDOWN] Worker smtp: cerrando');
         logger.flush(() => process.exit(0));
         return;
     }

--- a/workers/submit.js
+++ b/workers/submit.js
@@ -455,6 +455,21 @@ parentPort.on('message', message => {
         }
     }
 
+    if (message && message.cmd === 'gracefulShutdown') {
+        logger.info({ msg: '[SHUTDOWN] Worker submit: cerrando submitWorker (esperando job activo)' });
+        submitWorker
+            .close()
+            .then(() => {
+                logger.info({ msg: '[SHUTDOWN] Worker submit: submitWorker cerrado' });
+                process.exit(0);
+            })
+            .catch(err => {
+                logger.error({ msg: '[SHUTDOWN] Worker submit: error cerrando submitWorker', err });
+                process.exit(1);
+            });
+        return;
+    }
+
     if (message && message.cmd === 'call' && message.mid) {
         return onCommand(message.message)
             .then(response => {

--- a/workers/submit.js
+++ b/workers/submit.js
@@ -456,15 +456,15 @@ parentPort.on('message', message => {
     }
 
     if (message && message.cmd === 'gracefulShutdown') {
-        logger.info({ msg: '[SHUTDOWN] Worker submit: cerrando submitWorker (esperando job activo)' });
+        console.log('[SHUTDOWN] Worker submit: cerrando submitWorker (esperando job activo)');
         submitWorker
             .close()
             .then(() => {
-                logger.info({ msg: '[SHUTDOWN] Worker submit: submitWorker cerrado' });
+                console.log('[SHUTDOWN] Worker submit: submitWorker cerrado');
                 process.exit(0);
             })
             .catch(err => {
-                logger.error({ msg: '[SHUTDOWN] Worker submit: error cerrando submitWorker', err });
+                console.log(`[SHUTDOWN] Worker submit: error cerrando submitWorker: ${err.message}`);
                 process.exit(1);
             });
         return;

--- a/workers/webhooks.js
+++ b/workers/webhooks.js
@@ -158,15 +158,15 @@ parentPort.on('message', message => {
     }
 
     if (message && message.cmd === 'gracefulShutdown') {
-        logger.info({ msg: '[SHUTDOWN] Worker webhooks: cerrando notifyWorker (esperando job activo)' });
+        console.log('[SHUTDOWN] Worker webhooks: cerrando notifyWorker (esperando job activo)');
         notifyWorker
             .close()
             .then(() => {
-                logger.info({ msg: '[SHUTDOWN] Worker webhooks: notifyWorker cerrado' });
+                console.log('[SHUTDOWN] Worker webhooks: notifyWorker cerrado');
                 process.exit(0);
             })
             .catch(err => {
-                logger.error({ msg: '[SHUTDOWN] Worker webhooks: error cerrando notifyWorker', err });
+                console.log(`[SHUTDOWN] Worker webhooks: error cerrando notifyWorker: ${err.message}`);
                 process.exit(1);
             });
         return;

--- a/workers/webhooks.js
+++ b/workers/webhooks.js
@@ -157,6 +157,21 @@ parentPort.on('message', message => {
         }
     }
 
+    if (message && message.cmd === 'gracefulShutdown') {
+        logger.info({ msg: '[SHUTDOWN] Worker webhooks: cerrando notifyWorker (esperando job activo)' });
+        notifyWorker
+            .close()
+            .then(() => {
+                logger.info({ msg: '[SHUTDOWN] Worker webhooks: notifyWorker cerrado' });
+                process.exit(0);
+            })
+            .catch(err => {
+                logger.error({ msg: '[SHUTDOWN] Worker webhooks: error cerrando notifyWorker', err });
+                process.exit(1);
+            });
+        return;
+    }
+
     if (message && message.cmd === 'call' && message.mid) {
         return onCommand(message.message)
             .then(response => {


### PR DESCRIPTION
## Problema

Los banners de shutdown se veían como JSON de pino:
\`{"level":30,"time":...,"msg":"=====\\n GRACEFUL SHUTDOWN INICIADO\\n=====",...}\`

## Fix

Reemplaza \`logger.info\` por \`console.log\` en todos los mensajes de shutdown → output limpio en \`kubectl logs\`:

\`\`\`
================================================================
 GRACEFUL SHUTDOWN INICIADO
================================================================
 Signal:              SIGTERM
 Pod:                 emailengine-xxx
 Timestamp:           2026-03-18T01:35:34.176Z
 Workers al inicio:   5 (api, imap)
================================================================

[SHUTDOWN] Señal enviada a worker: api (threadId: 1)
[SHUTDOWN] Worker api terminado (code: 0) - 0.2s
...
================================================================
 SHUTDOWN COMPLETADO
================================================================
 Tiempo total:        1.0s
 Workers al inicio:   5
 Workers al final:    0
================================================================
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)