### PR TITLE
fix(accounts): prevent transient Disconnected state during rolling updates

### DIFF
--- a/lib/email-client/gmail-client.js
+++ b/lib/email-client/gmail-client.js
@@ -477,7 +477,7 @@ class GmailClient extends BaseClient {
     /**
      * Closes Gmail connection and stops watch renewal
      */
-    async close() {
+    async close({ skipStateUpdate = false } = {}) {
         clearTimeout(this.renewWatchTimer);
         clearTimeout(this.fallbackPollingTimer);
         this.closed = true;
@@ -487,7 +487,10 @@ class GmailClient extends BaseClient {
         this.cachedLabelsTime = null;
         this.pendingHistoryId = null;
 
-        if (['init', 'connecting', 'syncing', 'connected'].includes(this.state)) {
+        // During graceful pod shutdown, skip writing 'disconnected' to Redis.
+        // A surviving pod is already managing this account with state='connected',
+        // and overwriting it would cause a transient "Disconnected" flash in the UI.
+        if (!skipStateUpdate && ['init', 'connecting', 'syncing', 'connected'].includes(this.state)) {
             this.state = 'disconnected';
             await this.setStateVal();
             await emitChangeEvent(this.logger, this.account, 'state', this.state);

--- a/lib/email-client/outlook-client.js
+++ b/lib/email-client/outlook-client.js
@@ -363,12 +363,15 @@ class OutlookClient extends BaseClient {
     /**
      * Close the client connection and clean up resources
      */
-    async close() {
+    async close({ skipStateUpdate = false } = {}) {
         clearTimeout(this.renewWatchTimer);
         clearTimeout(this.renewRetryTimer);
         this.closed = true;
 
-        if (['init', 'connecting', 'syncing', 'connected'].includes(this.state)) {
+        // During graceful pod shutdown, skip writing 'disconnected' to Redis.
+        // A surviving pod is already managing this account with state='connected',
+        // and overwriting it would cause a transient "Disconnected" flash in the UI.
+        if (!skipStateUpdate && ['init', 'connecting', 'syncing', 'connected'].includes(this.state)) {
             this.state = 'disconnected';
             await this.setStateVal();
             await emitChangeEvent(this.logger, this.account, 'state', this.state);

--- a/server.js
+++ b/server.js
@@ -1095,7 +1095,7 @@ let spawnWorker = async type => {
                             reassignmentPending = false;
                             assignAccounts().catch(err => logger.error({ msg: 'Unable to reassign accounts (failsafe)', err }));
                         }
-                    }, 10000); // 10 second timeout
+                    }, 2000); // 2s — reduced from 10s to minimize Disconnected window on scale-down
 
                     logger.info({
                         msg: 'Worker crashed, waiting for restart before reassignment',
@@ -2978,15 +2978,19 @@ const gracefulShutdown = async signal => {
     logger.flush(() => process.exit(0));
 };
 
-process.on('SIGTERM', () => gracefulShutdown('SIGTERM').catch(err => {
-    logger.error({ msg: 'Error durante graceful shutdown', err });
-    process.exit(1);
-}));
+process.on('SIGTERM', () =>
+    gracefulShutdown('SIGTERM').catch(err => {
+        logger.error({ msg: 'Error durante graceful shutdown', err });
+        process.exit(1);
+    })
+);
 
-process.on('SIGINT', () => gracefulShutdown('SIGINT').catch(err => {
-    logger.error({ msg: 'Error durante graceful shutdown', err });
-    process.exit(1);
-}));
+process.on('SIGINT', () =>
+    gracefulShutdown('SIGINT').catch(err => {
+        logger.error({ msg: 'Error durante graceful shutdown', err });
+        process.exit(1);
+    })
+);
 
 // START APPLICATION
 

--- a/workers/imap.js
+++ b/workers/imap.js
@@ -782,7 +782,7 @@ class ConnectionHandler {
         };
     }
 
-    async kill() {
+    async kill({ graceful = false } = {}) {
         if (this.killed) {
             return;
         }
@@ -791,7 +791,9 @@ class ConnectionHandler {
 
         this.accounts.forEach(accountObject => {
             if (accountObject && accountObject.connection) {
-                accountObject.connection.close();
+                // During graceful shutdown, skip writing 'disconnected' to Redis so
+                // surviving pods do not see a transient Disconnected state in the UI.
+                accountObject.connection.close({ skipStateUpdate: graceful });
             }
         });
 
@@ -977,7 +979,7 @@ parentPort.on('message', message => {
     if (message && message.cmd === 'gracefulShutdown') {
         console.log('[SHUTDOWN] Worker imap: iniciando kill de conexiones IMAP');
         connectionHandler
-            .kill()
+            .kill({ graceful: true })
             .then(() => {
                 console.log('[SHUTDOWN] Worker imap: conexiones IMAP cerradas');
                 process.exit(0);


### PR DESCRIPTION
## Problema

Durante rolling updates y scale-down, las cuentas aparecian brevemente como **Disconnected** en la UI.

**Root cause**: `close()` en `GmailClient`/`OutlookClient` escribia `state='disconnected'` a Redis durante el graceful shutdown del pod, sobreescribiendo el `state='connected'` del pod sobreviviente.

## Fix

- `GmailClient.close({ skipStateUpdate })` no escribe `disconnected` a Redis en shutdown limpio
- `OutlookClient.close({ skipStateUpdate })` igual
- `ConnectionHandler.kill({ graceful })` pasa `skipStateUpdate: true` en shutdown graceful
- `server.js` orphan failsafe timeout 10s -> 2s (recuperacion mas rapida en scale-down)

## Validacion en Staging

3+ rolling updates consecutivos sin ningun Disconnected:

```
total=6 | connected=5 | disconnected=0
```

## Archivos

- `lib/email-client/gmail-client.js`
- `lib/email-client/outlook-client.js`
- `workers/imap.js`
- `server.js`