### PR TITLE
ci(staging): migrate deploy-staging.yml to AWS EKS + ECR

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -13,15 +13,18 @@ on:
         default: false
 
 env:
-  REGISTRY: registry.digitalocean.com/clientify
-  IMAGE: registry.digitalocean.com/clientify/emailengine-staging
-  MANIFESTS_REPO: contacteitor/clientify-manifiestos-kubernetes
-  K8S_CLUSTER: clientify-staging-k8s
+  AWS_REGION: eu-central-1
+  AWS_ACCOUNT_ID: "105028894218"
+  REGISTRY: 105028894218.dkr.ecr.eu-central-1.amazonaws.com/clientify
+  IMAGE_NAME: emailengine-staging
+  IMAGE: 105028894218.dkr.ecr.eu-central-1.amazonaws.com/clientify/emailengine-staging
+  MANIFESTS_REPO: ClientifySL/clientify-manifiestos-kubernetes
+  K8S_CLUSTER: clientify-api-staging
   NAMESPACE: emailengine-staging
 
 jobs:
   # ---------------------------------------------------------------------------
-  # Job 1: Build & Push imagen a DO Registry
+  # Job 1: Build & Push imagen a ECR
   # ---------------------------------------------------------------------------
   build:
     name: Build & Push Image
@@ -41,13 +44,29 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Install doctl
-        uses: digitalocean/action-doctl@v2
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
         with:
-          token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+          aws-access-key-id: ${{ secrets.AWS_STAGING_ECR_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_STAGING_ECR_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
 
-      - name: Log in to DigitalOcean Registry
-        run: doctl registry login --expiry-seconds 3600
+      - name: Log in to Amazon ECR
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Ensure ECR repository exists
+        run: |
+          REPO="clientify/${{ env.IMAGE_NAME }}"
+          if ! aws ecr describe-repositories --repository-names "$REPO" --region "$AWS_REGION" > /dev/null 2>&1; then
+            echo "Creando repositorio ECR: $REPO"
+            aws ecr create-repository \
+              --repository-name "$REPO" \
+              --region "$AWS_REGION" \
+              --image-scanning-configuration scanOnPush=true \
+              --image-tag-mutability MUTABLE > /dev/null
+          else
+            echo "Repositorio ECR ya existe: $REPO"
+          fi
 
       - name: Generate version tag
         id: version
@@ -70,7 +89,7 @@ jobs:
             COMMIT_SHA=${{ github.sha }}
             BUILD_TIME=${{ github.event.repository.updated_at }}
           cache-from: type=registry,ref=${{ env.IMAGE }}:staging-latest
-          cache-to: type=inline
+          cache-to: type=registry,ref=${{ env.IMAGE }}:staging-latest,mode=max
 
   # ---------------------------------------------------------------------------
   # Job 2: Deploy al cluster (después del build)
@@ -81,11 +100,6 @@ jobs:
     needs: build
 
     steps:
-      - name: Install doctl
-        uses: digitalocean/action-doctl@v2
-        with:
-          token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
-
       - name: Get version
         id: version
         run: |
@@ -104,8 +118,8 @@ jobs:
         run: |
           TAG=${{ steps.version.outputs.VERSION }}
           sed -i "s|image: ${{ env.IMAGE }}:[a-zA-Z0-9._-]*|image: ${{ env.IMAGE }}:${TAG}|g" \
-            manifests/emailengine/staging/deployment.yaml
-          echo "Updated deployment.yaml → tag: ${TAG}"
+            manifests/emailengine/staging/app/deployment.yaml
+          echo "Updated app/deployment.yaml → tag: ${TAG}"
 
       - name: Commit and push manifest changes
         run: |
@@ -113,7 +127,7 @@ jobs:
           cd manifests
           git config user.name "GitHub Actions"
           git config user.email "actions@github.com"
-          git add emailengine/staging/deployment.yaml
+          git add emailengine/staging/app/deployment.yaml
 
           if git diff --staged --quiet; then
             echo "No hay cambios para commitear"
@@ -139,10 +153,11 @@ jobs:
             echo "DEPLOYMENT FALLIDO (ver logs arriba)"
           fi
           echo "=========================================="
-          echo "Namespace:  ${{ env.NAMESPACE }}"
-          echo "Branch:     ${{ github.ref_name }}"
-          echo "Commit:     ${{ github.sha }}"
-          echo "Image tag:  ${TAG}"
-          echo "URL:        https://ee-staging.clientify.com"
+          echo "Cluster:     ${{ env.K8S_CLUSTER }} (EKS · ${{ env.AWS_REGION }})"
+          echo "Namespace:   ${{ env.NAMESPACE }}"
+          echo "Branch:      ${{ github.ref_name }}"
+          echo "Commit:      ${{ github.sha }}"
+          echo "Image:       ${{ env.IMAGE }}:${TAG}"
+          echo "URL:         https://ee-staging.clientify.com"
           echo "ArgoCD sync: https://argocd.clientify.com/applications/emailengine-staging"
           echo "=========================================="


### PR DESCRIPTION
## Summary
- Reemplaza DigitalOcean Registry por **Amazon ECR** (`105028894218.dkr.ecr.eu-central-1.amazonaws.com/clientify/emailengine-staging`)
- Sustituye `doctl` por `aws-actions/configure-aws-credentials@v4` + `aws-actions/amazon-ecr-login@v2`
- Actualiza path del manifiesto a `emailengine/staging/app/deployment.yaml` (subdirectorio `app/`)
- Cluster destino: EKS `clientify-api-staging` (eu-central-1)

## Secrets requeridos (org-level en ClientifySL)
- `AWS_STAGING_ECR_ACCESS_KEY_ID`
- `AWS_STAGING_ECR_SECRET_ACCESS_KEY`

Mismo patrón que `DIGITALOCEAN_ACCESS_TOKEN` a nivel org.

## Test plan
- [ ] Secrets org-level configurados en ClientifySL
- [ ] Merge a `staging` → ECR push `clientify/emailengine-staging:\${SHA}`
- [ ] Commit automático en manifestos (`emailengine/staging/app/deployment.yaml`)
- [ ] ArgoCD `emailengine-staging` sincroniza
- [ ] Pod Running y https://ee-staging.clientify.com responde

🤖 Generated with [Claude Code](https://claude.com/claude-code)